### PR TITLE
Normalize directory path

### DIFF
--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import { normalize } from 'node:path'
+import { resolve } from 'node:path'
 import type { ResolvedConfig } from 'vite'
 import type { PutObjectCommandOutput } from '@aws-sdk/client-s3'
 
@@ -32,7 +32,7 @@ export default class Uploader {
 
     this.client = new S3(this.options.clientConfig)
 
-    this.directory = this.options.directory ? this.options.directory : normalize(`${this.vite.root}/${this.vite.build.outDir}`)
+    this.directory = resolve(this.vite.root, (this.options.directory ? this.options.directory : this.vite.build.outDir))
   }
 
   uploadFile(fileName: string, file: string): Promise<PutObjectCommandOutput> {


### PR DESCRIPTION
While `build.outDir` specified with a dot, like:

```
build: {
  outDir: "./build",
}
```

result path of s3 object was calculated wrong. Path normalization fixes it.