### PR TITLE
Vite 7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project sticks to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added `Vite 7` support
 
 ## 1.7.1 - 2025-03-24
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "build": "esno scripts/build.ts"
   },
   "peerDependencies": {
-    "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+    "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0",


### PR DESCRIPTION
Added support to Vite 7, followed the exact same patter as the [Vite 6 update PR](https://github.com/SergkeiM/vite-plugin-s3/pull/199). This closes [Issue 290](https://github.com/SergkeiM/vite-plugin-s3/issues/290).
I've checked Vite's 7 [CHANGELOG.md](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md#-breaking-changes) breaking changes and none is used in this project so this should work fine without any additional changes to the project.