### PR TITLE
Fix: move es-toolkit & kolorist to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.0.0",
+        "es-toolkit": "^1.39.7",
+        "kolorist": "^1.7.0",
         "mime-types": "^3.0.1",
         "recursive-readdir": "^2.2.3"
       },
@@ -19,8 +21,6 @@
         "@types/node": "^24.0.10",
         "@types/recursive-readdir": "^2.2.1",
         "@vitest/ui": "^3.2.4",
-        "es-toolkit": "^1.39.7",
-        "kolorist": "^1.7.0",
         "tsup": "^8.5.0",
         "typescript": "^5.8.3",
         "vitest": "^3.2.4"
@@ -4183,7 +4183,6 @@
       "version": "1.39.7",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.7.tgz",
       "integrity": "sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw==",
-      "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -5599,8 +5598,7 @@
     "node_modules/kolorist": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.7.0.tgz",
-      "integrity": "sha512-ymToLHqL02udwVdbkowNpzjFd6UzozMtshPQKVi5k1EjKRqKqBrOnE9QbLEb0/pV76SAiIT13hdL8R6suc+f3g==",
-      "dev": true
+      "integrity": "sha512-ymToLHqL02udwVdbkowNpzjFd6UzozMtshPQKVi5k1EjKRqKqBrOnE9QbLEb0/pV76SAiIT13hdL8R6suc+f3g=="
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.0.0",
     "mime-types": "^3.0.1",
-    "recursive-readdir": "^2.2.3"
+    "recursive-readdir": "^2.2.3",
+    "es-toolkit": "^1.39.7",
+    "kolorist": "^1.7.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.16.2",
@@ -60,8 +62,6 @@
     "@types/node": "^24.0.10",
     "@types/recursive-readdir": "^2.2.1",
     "@vitest/ui": "^3.2.4",
-    "es-toolkit": "^1.39.7",
-    "kolorist": "^1.7.0",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"


### PR DESCRIPTION
`es-toolkit` & `kolorist` libraries are used at runtime but were only in `devDependencies`, causing consumers of the plugin to get ERR_MODULE_NOT_FOUND. This PR moves it to `dependencies`.