### PR TITLE
Option to disable parallel uploads

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,10 @@ export interface Options {
    * By default: `build.outDir`.
    */
   directory?: string | null
+  /**
+   * Disable parallel uploads if timouts or other issues occur.
+   */
+  disableParallelUploads?: boolean
 }
 
 /**

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -59,8 +59,16 @@ export default class Uploader {
   }
 
   async uploadFiles(files: File[]): Promise<PutObjectCommandOutput[]> {
-    const uploadFiles = files.map((file: File) => this.uploadFile(file.name, file.path))
+    if (this.options.disableParallelUploads) {
+      const uploadResponses: PutObjectCommandOutput[] = []
+      for (const file of files) {
+        const response = await this.uploadFile(file.name, file.path)
+        uploadResponses.push(response)
+      }
+      return uploadResponses
+    }
 
+    const uploadFiles = files.map((file: File) => this.uploadFile(file.name, file.path))
     return await Promise.all(uploadFiles)
   }
 

--- a/tests/uploader.test.ts
+++ b/tests/uploader.test.ts
@@ -75,4 +75,15 @@ describe('uploader', () => {
     expect(results).toHaveLength(2)
     expect(results[0]).toHaveProperty('ETag', 'mock-etag')
   })
+
+  it('should upload multiple files sequentially', async () => {
+    const files: File[] = [
+      { name: 'file1.txt', path: '/mock/file1.txt' },
+      { name: 'file2.js', path: '/mock/file2.js' },
+    ]
+    uploader.options.disableParallelUploads = true
+    const results = await uploader.uploadFiles(files)
+    expect(results).toHaveLength(2)
+    expect(results[0]).toHaveProperty('ETag', 'mock-etag')
+  })
 })


### PR DESCRIPTION
We have been having issues with uploads timing out when all files uploads are started at the same time