### PR TITLE
feat(registry): Add Vite plugin registry compatibility metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 S3 compatible file uploader Plugin for Vite
 
 ![vite-plugin-s3 banner](https://repository-images.githubusercontent.com/613344824/d377d1f4-94e5-49e9-a169-85e4b5653188)
-
 <p>
   <a href="https://www.npmjs.com/package/@froxz/vite-plugin-s3"><img src="https://img.shields.io/npm/v/@froxz/vite-plugin-s3.svg?style=flat&colorA=18181B&colorB=33A6B8" alt="Version"></a>
   <a href="https://www.npmjs.com/package/@froxz/vite-plugin-s3"><img src="https://img.shields.io/npm/dm/@froxz/vite-plugin-s3.svg?style=flat&colorA=18181B&colorB=33A6B8" alt="Downloads"></a>

--- a/package.json
+++ b/package.json
@@ -37,6 +37,14 @@
   "files": [
     "dist"
   ],
+  "$schema": "https://raw.githubusercontent.com/vitejs/vite-plugin-registry/refs/heads/main/data/schema/extended-package-json.schema.json",
+  "compatiblePackages": {
+    "schemaVersion": 1,
+    "vite": {
+      "type": "compatible",
+      "versions": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+    }
+  },
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
Adds `"$schema"` and `compatiblePackages` to `package.json` to formally declare the plugin's compatibility with the Vite plugin registry. This enhances discoverability and provides explicit version support information for Vite users.
