### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,8 @@ name: Publish Package
 on:
   release:
     types: [published]
-
+permissions:
+  contents: read
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration by explicitly setting the required permissions for the workflow. The change grants the workflow read access to repository contents, which is a best practice for security.

* Set `permissions.contents` to `read` in `.github/workflows/publish.yml` to restrict workflow token permissions.